### PR TITLE
Add Laravel 10 Support

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -16,12 +16,9 @@ jobs:
       - name: Validate Composer configuration
         run: composer validate --strict
 
-      # - name: Run composer normalize
-      #   uses: docker://ergebnis/composer-normalize-action:latest
       - name: Normalize composer.json
         run: |
           composer global require ergebnis/composer-normalize
-          # composer normalize
           composer normalize --indent-style=space --indent-size=4 --no-check-lock --no-update-lock --no-interaction --ansi
 
       - uses: stefanzweifel/git-auto-commit-action@v4.0.0

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -16,10 +16,12 @@ jobs:
       - name: Validate Composer configuration
         run: composer validate --strict
 
+      # - name: Run composer normalize
+      #   uses: docker://ergebnis/composer-normalize-action:latest
       - name: Normalize composer.json
         run: |
           composer global require ergebnis/composer-normalize
-          composer config allow-plugins.ergebnis/composer-normalize true
+          # composer normalize
           composer normalize --indent-style=space --indent-size=4 --no-check-lock --no-update-lock --no-interaction --ansi
 
       - uses: stefanzweifel/git-auto-commit-action@v4.0.0

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Normalize composer.json
         run: |
           composer global require ergebnis/composer-normalize
+          composer config allow-plugins.ergebnis/composer-normalize true
           composer normalize --indent-style=space --indent-size=4 --no-check-lock --no-update-lock --no-interaction --ansi
 
       - uses: stefanzweifel/git-auto-commit-action@v4.0.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,17 +12,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 7.4]
-        laravel: [9.*,8.*]
+        php: [8.1, 8.0, 7.4]
+        laravel: [10.*,9.*,8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 9.*
             php: 7.4
+          - laravel: 10.*
+            php: 7.4,8.0
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,12 +12,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.0]
+        php: [8.2,8.1]
         laravel: [10.*,9.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        exclude:
-          - laravel: 10.*
-            php: 8.0
         include:
           - laravel: 9.*
             testbench: 7.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,9 @@ jobs:
           - laravel: 9.*
             php: 7.4
           - laravel: 10.*
-            php: 7.4,8.0
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
         include:
           - laravel: 8.*
             testbench: 6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,8 @@ jobs:
         laravel: [10.*,9.*,8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
+          - laravel: 8.*
+            php: 8.1
           - laravel: 9.*
             php: 7.4
           - laravel: 10.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,21 +12,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.0, 7.4]
-        laravel: [10.*,9.*,8.*]
+        php: [8.1, 8.0]
+        laravel: [10.*,9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - laravel: 8.*
-            php: 8.1
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 10.*
-            php: 7.4
           - laravel: 10.*
             php: 8.0
         include:
-          - laravel: 8.*
-            testbench: 6.*
           - laravel: 9.*
             testbench: 7.*
           - laravel: 10.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-unavatar` will be documented in this file
 
+## 0.4.0 - 2023-07-28
+
+- add Laravel 10 support
+
 ## 0.3.0 - 2022-04-08
 
 - add Laravel 9 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `laravel-unavatar` will be documented in this file
 
-## 0.4.0 - 2023-07-28
+## 0.5.0 - 2023-07-28
 
 - add Laravel 10 support
 - drop Laravel 8 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `laravel-unavatar` will be documented in this file
 ## 0.4.0 - 2023-07-28
 
 - add Laravel 10 support
+- drop Laravel 8 support
 
 ## 0.3.0 - 2022-04-08
 

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
             "Astrotomic\\Unavatar\\Laravel\\Tests\\": "tests"
         }
     },
-    "config": {
-        "sort-packages": true
-    },
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1",
         "ext-json": "*",
-        "astrotomic/php-unavatar": "^0.2.0 || ^0.3.0",
+        "astrotomic/php-unavatar": "^0.3.0",
         "illuminate/support": "^8.0 || ^9.0 || ^10.0",
         "illuminate/view": "^8.0 || ^9.0 || ^10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
         "source": "https://github.com/Astrotomic/laravel-unavatar"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4 || ^8.0 || ^8.1",
         "ext-json": "*",
         "astrotomic/php-unavatar": "^0.2.0 || ^0.3.0",
-        "illuminate/support": "^8.0 || ^9.0",
-        "illuminate/view": "^8.0 || ^9.0"
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/view": "^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "orchestra/testbench": "^6.0 || ^7.0",
+        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
         "source": "https://github.com/Astrotomic/laravel-unavatar"
     },
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "^8.0 || ^8.1",
         "ext-json": "*",
         "astrotomic/php-unavatar": "^0.3.0",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/view": "^8.0 || ^9.0 || ^10.0"
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/view": "^9.0 || ^10.0"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0",
-        "phpunit/phpunit": "^9.3"
+        "orchestra/testbench": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -9,7 +9,7 @@ final class ComponentTest extends TestCase
     {
         $expected = <<<'HTML'
             <img
-                src="https://unavatar.now.sh/astrotomic.info"
+                src="https://unavatar.io/astrotomic.info"
                 alt="Astrotomic avatar"
                 loading="lazy"
             />
@@ -23,7 +23,7 @@ final class ComponentTest extends TestCase
     {
         $expected = <<<'HTML'
             <img
-                src="https://unavatar.now.sh/astrotomic.info/?fallback=https%3A%2F%2Fexample.com%2Favatar.jpg"
+                src="https://unavatar.io/astrotomic.info/?fallback=https%3A%2F%2Fexample.com%2Favatar.jpg"
                 alt="astrotomic.info avatar"
                 loading="lazy"
             />
@@ -37,7 +37,7 @@ final class ComponentTest extends TestCase
     {
         $expected = <<<'HTML'
             <img
-                src="https://unavatar.now.sh/clearbit/astrotomic.info"
+                src="https://unavatar.io/clearbit/astrotomic.info"
                 alt="astrotomic.info avatar"
                 loading="lazy"
             />
@@ -51,7 +51,7 @@ final class ComponentTest extends TestCase
     {
         $expected = <<<'HTML'
             <img
-                src="https://unavatar.now.sh/deviantart/astrotomic"
+                src="https://unavatar.io/deviantart/astrotomic"
                 alt="astrotomic avatar"
                 loading="lazy"
             />
@@ -65,7 +65,7 @@ final class ComponentTest extends TestCase
     {
         $expected = <<<'HTML'
             <img
-                src="https://unavatar.now.sh/dribbble/astrotomic"
+                src="https://unavatar.io/dribbble/astrotomic"
                 alt="astrotomic avatar"
                 loading="lazy"
             />

--- a/tests/UnavatarTest.php
+++ b/tests/UnavatarTest.php
@@ -20,7 +20,7 @@ final class UnavatarTest extends TestCase
         $unavatar = Unavatar::github('Gummibeer');
 
         static::assertArrayHasKey(Renderable::class, class_implements($unavatar));
-        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.now.sh/github/Gummibeer" />', $unavatar->render());
+        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->render());
     }
 
     /** @test */
@@ -29,7 +29,7 @@ final class UnavatarTest extends TestCase
         $unavatar = Unavatar::github('Gummibeer');
 
         static::assertArrayHasKey(Htmlable::class, class_implements($unavatar));
-        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.now.sh/github/Gummibeer" />', $unavatar->toHtml());
+        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->toHtml());
     }
 
     /** @test */
@@ -42,7 +42,7 @@ final class UnavatarTest extends TestCase
         $redirect = $unavatar->toResponse(Request::createFromGlobals());
 
         static::assertInstanceOf(RedirectResponse::class, $redirect);
-        static::assertSame('https://unavatar.now.sh/github/Gummibeer', $redirect->getTargetUrl());
+        static::assertSame('https://unavatar.io/github/Gummibeer', $redirect->getTargetUrl());
     }
 
     /** @test */

--- a/tests/UnavatarTest.php
+++ b/tests/UnavatarTest.php
@@ -20,7 +20,7 @@ final class UnavatarTest extends TestCase
         $unavatar = Unavatar::github('Gummibeer');
 
         static::assertArrayHasKey(Renderable::class, class_implements($unavatar));
-        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->render());
+        static::assertSame('<img alt="Gummibeer&#039;s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->render());
     }
 
     /** @test */
@@ -29,7 +29,7 @@ final class UnavatarTest extends TestCase
         $unavatar = Unavatar::github('Gummibeer');
 
         static::assertArrayHasKey(Htmlable::class, class_implements($unavatar));
-        static::assertSame('<img alt="Gummibeer\'s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->toHtml());
+        static::assertSame('<img alt="Gummibeer&#039;s github avatar" src="https://unavatar.io/github/Gummibeer" />', $unavatar->toHtml());
     }
 
     /** @test */


### PR DESCRIPTION
In order to  properly add Laravel 10 support, this commit adds the 
appropriate laravel and testbench version. This commit also removes
the support for php 8.0 and below  as well as laravel 8.0 and below due
end of life or soon to be end of life. The `CHANGELOG.md` file was also
updated in this commit.